### PR TITLE
Black and profiles

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,4 +37,8 @@ AMAZON_APP_ID=amazon app id here
 GMAPS_APIKEY=google api key here
 
 # Compose options:
+# Below is a list of comma-separated values to enable set of containers. `dev` is a flag for all dev
+# containers and there are specific ones if you want to hand-pick the services to run
+# This setting is automatically passed to docker compose.
+# To learn more about profiles check out: https://docs.docker.com/compose/profiles/
 COMPOSE_PROFILES=dev,pgadmin,black

--- a/.env.example
+++ b/.env.example
@@ -32,3 +32,6 @@ AMAZON_APP_ID=amazon app id here
 
 # API_KEYS
 GMAPS_APIKEY=google api key here
+
+# Compose options:
+COMPOSE_PROFILES=dev,pgadmin,black

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,6 @@
+# Enables hot reload for the server.
+UVICORN__RELOAD=1
+
 SERVER_NAME=Google Maps
 SERVER_HOST=http://127.0.0.1:7000
 

--- a/black/Dockerfile
+++ b/black/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.8-alpine as builder
+
+RUN set -eux \
+        && apk add --no-cache \
+                gcc \
+                musl-dev \
+    && pip install --upgrade pip black[d]
+
+FROM python:3.8-alpine
+
+COPY --from=builder /usr/local/lib/python3.8/site-packages/ \
+    /usr/local/lib/python3.8/site-packages/
+COPY --from=builder /usr/local/bin/blackd /usr/local/bin/blackd
+
+WORKDIR app
+EXPOSE 45484
+ENTRYPOINT ["blackd", "--bind-host", "0.0.0.0", "--bind-port", "45484"]

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,26 @@
+version: '3.8'
+services:
+  fastapi:
+    volumes:
+      - ./:/src
+
+  pgadmin:
+    profiles:
+      - dev
+      - pgadmin
+
+    container_name: pgadmin4_container
+    image: dpage/pgadmin4
+    platform: linux/amd64
+
+    environment:
+      PGADMIN_DEFAULT_EMAIL: admin@projectdim.org
+      PGADMIN_DEFAULT_PASSWORD: dim
+
+    ports:
+      - "5050:80"
+
+    restart: always
+    depends_on:
+      pgdatabase:
+        condition: service_healthy

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -24,3 +24,19 @@ services:
     depends_on:
       pgdatabase:
         condition: service_healthy
+
+  black:
+    profiles:
+      - dev
+      - black
+    # Uncompromising code formatter
+    # To integrate with IDE check: https://black.readthedocs.io/en/stable/integrations/editors.html
+    build:
+      context: .
+      dockerfile: black/Dockerfile
+
+    ports:
+      - "45484:45484"
+
+    volumes:
+      - ./:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,25 +33,6 @@ services:
     depends_on:
       pgdatabase:
         condition: service_healthy
-    volumes:
-      - ./:/src
-
-  pgadmin:
-    container_name: pgadmin4_container
-    image: dpage/pgadmin4
-    platform: linux/amd64
-
-    environment:
-      PGADMIN_DEFAULT_EMAIL: admin@projectdim.org
-      PGADMIN_DEFAULT_PASSWORD: dim
-
-    ports:
-      - "5050:80"
-
-    restart: always
-    depends_on:
-      pgdatabase:
-        condition: service_healthy
 
 volumes:
   pg-data:

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
 alembic upgrade heads
 python populate_db.py
-uvicorn app.main:app --host 0.0.0.0 --port 7000
+
+reload=""
+if [ "$UVICORN__RELOAD" == "1" ]; then
+    echo "Running in development mode"
+    reload="--reload"
+fi
+
+
+uvicorn app.main:app --host 0.0.0.0 --port 7000 $reload


### PR DESCRIPTION
This PR contains:

- New env variable `UVICORN__RELOAD` that enables or disables hot reload of the server
- Dev containers/settings moved to `docker-compose.override.yml`
- [Black](https://github.com/psf/black) container to enable live auto-formatting (needs to be integrated with IDEs)
- Docker compose profiles for `pgadmin` and `black`


If this goes through I'd be keen to setup pre-commit hook with black to also automatically format changed files on the commit so style stays consistent. With that I'll reformat all the code to reduce changes in future PRs.